### PR TITLE
refactor: Extract SVG Editor Bridge and Occlusion File Service from MainWindow.xaml.cs

### DIFF
--- a/ImageOcclusionEditorWinUI3/MainWindow.xaml.cs
+++ b/ImageOcclusionEditorWinUI3/MainWindow.xaml.cs
@@ -21,16 +21,10 @@
 
 using System;
 using System.IO;
-using System.Text;
-using System.Text.Json;
 using System.Threading.Tasks;
-using Hjg.Pngcs;
-using Hjg.Pngcs.Chunks;
+using ImageOcclusionEditorWinUI3.Services;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.Web.WebView2.Core;
-using SkiaSharp;
-using Svg.Skia;
 
 namespace ImageOcclusionEditorWinUI3
 {
@@ -39,12 +33,10 @@ namespace ImageOcclusionEditorWinUI3
     /// </summary>
     public sealed partial class MainWindow : Window
     {
-        private const string SvgEditorPath = "svg-edit/index.html";
-
         private readonly string _occlusionFilePath;
         private readonly string _backgroundFilePath;
-
-        private bool isWebViewReady = false;
+        private readonly SvgEditorBridge _svgEditorBridge;
+        private readonly OcclusionFileService _occlusionFileService;
 
         public MainWindow(string backgroundFilePath, string occlusionFilePath)
         {
@@ -52,6 +44,16 @@ namespace ImageOcclusionEditorWinUI3
 
             _backgroundFilePath = backgroundFilePath;
             _occlusionFilePath = occlusionFilePath;
+
+            _occlusionFileService = new OcclusionFileService();
+            _svgEditorBridge = new SvgEditorBridge(webView);
+
+            _svgEditorBridge.Ready += OnSvgEditorReady;
+            _svgEditorBridge.SaveRequested += OnSaveRequested;
+            _svgEditorBridge.SaveAndExitRequested += OnSaveAndExitRequested;
+            _svgEditorBridge.CancelRequested += OnCancelRequested;
+
+            Closed += OnWindowClosed;
         }
 
         private async void Grid_Loaded(object sender, RoutedEventArgs e)
@@ -63,419 +65,120 @@ namespace ImageOcclusionEditorWinUI3
                     "ImageOcclusionEditor",
                     "WebView2UserData");
 
-                CoreWebView2Environment env = await CoreWebView2Environment.CreateWithOptionsAsync(
-                    browserExecutableFolder: null,
-                    userDataFolder: userDataFolder,
-                    new CoreWebView2EnvironmentOptions
-                    {
-                        AdditionalBrowserArguments =
-                            "--disable-features=msSmartScreenProtection " +
-                            "--allow-file-access-from-files",
-                    });
+                var (width, height) = _occlusionFileService.GetImageDimensions(_backgroundFilePath);
+                Uri targetUri = SvgEditorNavigationBuilder.Build(_backgroundFilePath, width, height);
 
-                webView.NavigationCompleted += WebView_NavigationCompleted;
-                webView.WebMessageReceived += WebView_WebMessageReceived;
-
-                await webView.EnsureCoreWebView2Async(env);
-
-                webView.CoreWebView2.Settings.AreHostObjectsAllowed = true;
-                webView.CoreWebView2.Settings.IsWebMessageEnabled = true;
-                webView.CoreWebView2.Settings.AreDevToolsEnabled = false;
-                webView.CoreWebView2.Settings.IsGeneralAutofillEnabled = false;
-
-                GetImageSize(_backgroundFilePath, out int width, out int height);
-                var targetUri = $"{GetSvgEditorUri()}?{GenerateUrlParams(_backgroundFilePath, width, height)}";
-
-                webView.CoreWebView2.Navigate(targetUri);
+                await _svgEditorBridge.InitializeAsync(userDataFolder, targetUri);
             }
             catch (Exception ex)
             {
-                ShowError($"Error initializing WebView2: {ex.Message}");
+                await ShowErrorAsync($"Error initializing WebView2: {ex.Message}");
             }
         }
 
-        private async void WebView_NavigationCompleted(object sender, CoreWebView2NavigationCompletedEventArgs e)
+        private async void OnSvgEditorReady(object? sender, EventArgs e)
         {
-            if (e.IsSuccess)
+            try
             {
-                isWebViewReady = true;
+                Uri backgroundUri = new Uri(Path.GetFullPath(_backgroundFilePath));
+                await _svgEditorBridge.SetBackgroundAsync(backgroundUri);
 
-                await SetBackgroundInBrowser(_backgroundFilePath);
-
-                var svg = ReadSvgFromChunk(_occlusionFilePath);
+                string svg = _occlusionFileService.GetSvgOverlay(_occlusionFilePath);
                 if (!string.IsNullOrWhiteSpace(svg))
                 {
-                    await SetSvgInBrowserAsync(svg);
+                    await _svgEditorBridge.SetSvgContentAsync(svg);
                 }
 
-                // Inject keyboard shortcut handler
-                await InjectKeyboardShortcutHandler();
-            }
-        }
-
-        private async void WebView_WebMessageReceived(object sender, CoreWebView2WebMessageReceivedEventArgs e)
-        {
-            try
-            {
-                string message = e.TryGetWebMessageAsString();
-                await HandleKeyboardShortcutFromWebView2(message);
+                await _svgEditorBridge.InjectKeyboardShortcutsAsync();
             }
             catch (Exception ex)
             {
-                ShowError($"Error handling web message: {ex.Message}");
+                await ShowErrorAsync($"Error preparing SVG editor: {ex.Message}");
             }
         }
 
-        private async Task InjectKeyboardShortcutHandler()
+        private void OnCancelRequested(object? sender, EventArgs e)
         {
-            if (!isWebViewReady) return;
-
-            string script = @"
-                (function() {
-                    // Remove any existing event listener to avoid duplicates
-                    if (window.imageOcclusionKeyHandler) {
-                        document.removeEventListener('keydown', window.imageOcclusionKeyHandler, true);
-                        document.removeEventListener('keyup', window.imageOcclusionKeyHandler, true);
-                    }
-
-                    // Track if our handler is active
-                    window.imageOcclusionHandlerActive = true;
-
-                    // Define the keyboard handler
-                    window.imageOcclusionKeyHandler = function(e) {
-                        // Only handle if our handler is active
-                        if (!window.imageOcclusionHandlerActive) return;
-
-                        // Check for our specific shortcuts
-                        if (e.key === 'Escape') {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            e.stopImmediatePropagation();
-                            if (window.chrome && window.chrome.webview) {
-                                window.chrome.webview.postMessage('cancel');
-                            }
-                            return false;
-                        }
-                        else if (e.ctrlKey && e.shiftKey && (e.key === 'S' || e.key === 's')) {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            e.stopImmediatePropagation();
-                            if (window.chrome && window.chrome.webview) {
-                                window.chrome.webview.postMessage('save');
-                            }
-                            return false;
-                        }
-                        else if (e.ctrlKey && !e.shiftKey && (e.key === 'S' || e.key === 's')) {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            e.stopImmediatePropagation();
-                            if (window.chrome && window.chrome.webview) {
-                                window.chrome.webview.postMessage('saveExit');
-                            }
-                            return false;
-                        }
-                    };
-
-                    // Add the event listeners with capture phase to catch events early
-                    document.addEventListener('keydown', window.imageOcclusionKeyHandler, true);
-                    // Also add to window to ensure we catch everything
-                    window.addEventListener('keydown', window.imageOcclusionKeyHandler, true);
-
-                    // Add a backup using keyup as well for better reliability
-                    window.addEventListener('keyup', function(e) {
-                        if (!window.imageOcclusionHandlerActive) return;
-
-                        // Handle on keyup as backup for some cases
-                        if (e.key === 'Escape' ||
-                            (e.ctrlKey && (e.key === 'S' || e.key === 's'))) {
-                            e.preventDefault();
-                            e.stopPropagation();
-                        }
-                    }, true);
-
-                    console.log('Image Occlusion keyboard shortcuts injected successfully');
-
-                    // Re-inject periodically to ensure persistence
-                    setTimeout(function() {
-                        if (window.imageOcclusionHandlerActive &&
-                            window.chrome && window.chrome.webview) {
-                            console.log('Keyboard shortcut handler still active');
-                        }
-                    }, 5000);
-                })();
-            ";
-
-            try
-            {
-                await webView.CoreWebView2.ExecuteScriptAsync(script);
-            }
-            catch (Exception ex)
-            {
-                ShowError($"Error injecting keyboard handler: {ex.Message}");
-            }
+            Close();
         }
 
-        private async Task HandleKeyboardShortcutFromWebView2(string shortcut)
+        private async void OnSaveRequested(object? sender, EventArgs e)
         {
-            switch (shortcut?.ToLower())
-            {
-                case "cancel":
-                    this.Close();
-                    break;
-                case "save":
-                    try
-                    {
-                        await SaveOcclusionAsync();
-                    }
-                    catch (Exception ex)
-                    {
-                        ShowError($"save failed: {ex.Message}");
-                    }
-                    break;
-                case "saveexit":
-                    try
-                    {
-                        await SaveOcclusionAndExitAsync();
-                    }
-                    catch (Exception ex)
-                    {
-                        ShowError($"save and exit failed: {ex.Message}");
-                    }
-                    break;
-            }
+            await HandleSaveAsync(closeAfterSave: false, errorPrefix: "save failed");
         }
 
-        private void BtnCancel_Click(object sender, RoutedEventArgs e)
+        private async void OnSaveAndExitRequested(object? sender, EventArgs e)
         {
-            this.Close();
+            await HandleSaveAsync(closeAfterSave: true, errorPrefix: "save and exit failed");
         }
 
-        private async void BtnSave_Click(object sender, RoutedEventArgs e)
+        private async Task HandleSaveAsync(bool closeAfterSave, string errorPrefix)
         {
             try
             {
                 await SaveOcclusionAsync();
-            }
-            catch (Exception ex)
-            {
-                ShowError($"save failed: {ex.Message}");
-            }
-        }
 
-        private async void BtnSaveExit_Click(object sender, RoutedEventArgs e)
-        {
-            try
-            {
-                await SaveOcclusionAndExitAsync();
-            }
-            catch (Exception ex)
-            {
-                ShowError($"save and exit failed: {ex.Message}");
-            }
-        }
-
-        private Uri GetSvgEditorUri()
-        {
-            string appFolder = AppContext.BaseDirectory;
-            return new Uri($"file:///{Path.Combine(appFolder, SvgEditorPath)}");
-        }
-
-        private string GenerateUrlParams(string backgroundFilePath, int width, int height)
-        {
-            var urlParams = new StringBuilder();
-
-            AppendUrlParam(urlParams, "bkgd_url", backgroundFilePath);
-            AppendUrlParam(urlParams, "dimensions", $"{width},{height}");
-            AppendUrlParam(urlParams, "initFill[color]", Settings.FillColor);
-            AppendUrlParam(urlParams, "initFill[opacity]", "1");
-            AppendUrlParam(urlParams, "initStroke[color]", Settings.StrokeColor);
-            AppendUrlParam(urlParams, "initStroke[width]", Settings.StrokeWidth);
-            AppendUrlParam(urlParams, "initStroke[opacity]", "1");
-            AppendUrlParam(urlParams, "storagePrompt", "false");
-
-            return urlParams.ToString().TrimStart('&');
-        }
-
-        private void AppendUrlParam(StringBuilder sb, string key, string value)
-        {
-            if (sb.Length > 0)
-                sb.Append('&');
-            sb.Append(Uri.EscapeDataString(key));
-            sb.Append('=');
-            sb.Append(Uri.EscapeDataString(value));
-        }
-
-        private void GetImageSize(string filePath, out int width, out int height)
-        {
-            using var codec = SKCodec.Create(filePath);
-            width = codec.Info.Width;
-            height = codec.Info.Height;
-        }
-
-        private async Task SetBackgroundInBrowser(string backgroundFilePath)
-        {
-            if (!isWebViewReady) return;
-
-            string script = $"svgEditor.setBackground(\"\", \"{new Uri(backgroundFilePath).AbsoluteUri}\")";
-            try
-            {
-                await webView.CoreWebView2.ExecuteScriptAsync(script);
-            }
-            catch (Exception ex)
-            {
-                ShowError($"Error setting background in browser: {ex.Message}");
-            }
-        }
-
-        private async Task SetSvgInBrowserAsync(string svg)
-        {
-            if (!isWebViewReady) return;
-
-            svg = svg.Replace("\r", "").Replace("\n", "").Replace("'", "\\'");
-            string script = $"svgEditor.loadSvgString('{svg}')";
-
-            try
-            {
-                string result = await webView.CoreWebView2.ExecuteScriptAsync(script);
-                if (result == "false")
+                if (closeAfterSave)
                 {
-                    ShowError($"Failed to set SVG in browser!");
+                    Close();
                 }
             }
             catch (Exception ex)
             {
-                ShowError($"Error setting SVG in browser: {ex.Message}");
-            }
-        }
-
-        private async Task<string> GetSvgFromBrowserAsync()
-        {
-            if (!isWebViewReady) return string.Empty;
-
-            try
-            {
-                string result = await webView.CoreWebView2.ExecuteScriptAsync("svgEditor.svgCanvas.svgCanvasToString()");
-                return JsonSerializer.Deserialize(result, JsonContext.Default.String) ?? string.Empty;
-            }
-            catch (Exception ex)
-            {
-                ShowError($"Error getting SVG from browser: {ex.Message}");
-                return string.Empty;
-            }
-        }
-
-        private void CreateChunk(PngWriter pngw, string svg)
-        {
-            PngChunkSVGI chunk = new PngChunkSVGI(pngw.ImgInfo);
-            chunk.SetSVG(svg);
-            chunk.Priority = true;
-
-            pngw.GetChunksList().Queue(chunk);
-        }
-
-        private void WriteSvgToChunk(string tmpOcclusionFilePath, string svg)
-        {
-            using MemoryStream memoryStream = new MemoryStream();
-
-            using (var fileStream = File.OpenRead(tmpOcclusionFilePath))
-            {
-                fileStream.CopyTo(memoryStream);
-            }
-
-            memoryStream.Seek(0, SeekOrigin.Begin);
-
-            PngReader pngr = new PngReader(memoryStream);
-            PngWriter pngw = FileHelper.CreatePngWriter(tmpOcclusionFilePath, pngr.ImgInfo, true);
-
-            pngw.CopyChunksFirst(pngr, ChunkCopyBehaviour.COPY_ALL_SAFE);
-
-            CreateChunk(pngw, svg);
-
-            for (int row = 0; row < pngr.ImgInfo.Rows; row++)
-            {
-                ImageLine l1 = pngr.ReadRow(row);
-                pngw.WriteRow(l1, row);
-            }
-
-            pngw.CopyChunksLast(pngr, ChunkCopyBehaviour.COPY_ALL);
-
-            pngr.End();
-            pngw.End();
-        }
-
-        private static string ReadSvgFromChunk(string occlusionFilePath)
-        {
-            try
-            {
-                var pngr = FileHelper.CreatePngReader(occlusionFilePath);
-                PngChunkSVGI? chunk = (PngChunkSVGI?)pngr.GetChunksList().GetById1(PngChunkSVGI.ID);
-                pngr.End();
-                return chunk?.GetSVG() ?? string.Empty;
-            }
-            catch
-            {
-                NativeHelper.MessageBox(
-                    IntPtr.Zero,
-                    "Failed to read SVG data from PNG chunk. Please ensure the occlusion file is valid.",
-                    "Error - Image Occlusion Editor",
-                    NativeHelper.MB_OK | NativeHelper.MB_ICONERROR);
-                return string.Empty;
+                await ShowErrorAsync($"{errorPrefix}: {ex.Message}");
             }
         }
 
         private async Task SaveOcclusionAsync()
         {
-            string tmpOcclusionFilePath = Path.GetTempFileName();
-            string svg = await GetSvgFromBrowserAsync();
+            string svg = await _svgEditorBridge.GetSvgContentAsync();
 
             if (string.IsNullOrEmpty(svg))
             {
-                ShowError("Failed to get SVG data from browser.");
-                return;
+                throw new InvalidOperationException("Failed to get SVG data from browser.");
             }
 
-            using var sksvg = SKSvg.CreateFromSvg(svg);
-            sksvg.Save(
-                path: tmpOcclusionFilePath,
-                background: SKColors.Transparent,
-                format: SKEncodedImageFormat.Png
-            );
-
-            WriteSvgToChunk(tmpOcclusionFilePath, svg);
-
-            if (File.Exists(_occlusionFilePath))
-            {
-                File.Delete(_occlusionFilePath);
-            }
-
-            File.Move(tmpOcclusionFilePath, _occlusionFilePath);
+            await _occlusionFileService.SaveOcclusionAsync(_occlusionFilePath, svg);
         }
 
-        private async Task SaveOcclusionAndExitAsync()
+        private void BtnCancel_Click(object sender, RoutedEventArgs e)
         {
-            await SaveOcclusionAsync();
-            this.Close();
+            Close();
         }
 
-        private async void ShowError(string message)
+        private async void BtnSave_Click(object sender, RoutedEventArgs e)
         {
-            // In WinUI3, we can use ContentDialog for better user experience
+            await HandleSaveAsync(closeAfterSave: false, errorPrefix: "save failed");
+        }
+
+        private async void BtnSaveExit_Click(object sender, RoutedEventArgs e)
+        {
+            await HandleSaveAsync(closeAfterSave: true, errorPrefix: "save and exit failed");
+        }
+
+        private async Task ShowErrorAsync(string message)
+        {
             try
             {
-                var dialog = new ContentDialog()
+                var dialog = new ContentDialog
                 {
                     Title = "Error",
                     Content = message,
                     CloseButtonText = "OK",
-                    XamlRoot = this.Content.XamlRoot
+                    XamlRoot = Content.XamlRoot
                 };
+
                 await dialog.ShowAsync();
             }
             catch
             {
-                // Fallback to debug output if dialog fails
                 System.Diagnostics.Debug.WriteLine($"Error: {message}");
             }
+        }
+
+        private void OnWindowClosed(object sender, WindowEventArgs args)
+        {
+            _svgEditorBridge.Dispose();
         }
     }
 }

--- a/ImageOcclusionEditorWinUI3/Services/OcclusionFileService.cs
+++ b/ImageOcclusionEditorWinUI3/Services/OcclusionFileService.cs
@@ -1,0 +1,156 @@
+/*
+ * ImageOcclusionEditorWinUI3 - A WinUI 3 application for creating image occlusion cards
+ * Copyright (C) 2025 Shuai Zhang
+ *
+ * This file contains code derived from ImageOcclusionEditor by SuperMemo Community,
+ * which is licensed under the MIT License.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Hjg.Pngcs;
+using Hjg.Pngcs.Chunks;
+using SkiaSharp;
+using Svg.Skia;
+
+namespace ImageOcclusionEditorWinUI3.Services
+{
+    internal sealed class OcclusionFileService
+    {
+        public (int Width, int Height) GetImageDimensions(string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                throw new ArgumentException("File path cannot be null or whitespace.", nameof(filePath));
+            }
+
+            using var codec = SKCodec.Create(filePath);
+            return (codec.Info.Width, codec.Info.Height);
+        }
+
+        public string GetSvgOverlay(string occlusionFilePath)
+        {
+            if (string.IsNullOrWhiteSpace(occlusionFilePath))
+            {
+                throw new ArgumentException("File path cannot be null or whitespace.", nameof(occlusionFilePath));
+            }
+
+            try
+            {
+                var pngReader = FileHelper.CreatePngReader(occlusionFilePath);
+                PngChunkSVGI? chunk = (PngChunkSVGI?)pngReader.GetChunksList().GetById1(PngChunkSVGI.ID);
+                pngReader.End();
+                return chunk?.GetSVG() ?? string.Empty;
+            }
+            catch
+            {
+                ImageOcclusionEditorWinUI3.NativeHelper.MessageBox(
+                    IntPtr.Zero,
+                    "Failed to read SVG data from PNG chunk. Please ensure the occlusion file is valid.",
+                    "Error - Image Occlusion Editor",
+                    ImageOcclusionEditorWinUI3.NativeHelper.MB_OK | ImageOcclusionEditorWinUI3.NativeHelper.MB_ICONERROR);
+                return string.Empty;
+            }
+        }
+
+        public async Task SaveOcclusionAsync(string destinationOcclusionFilePath, string svg)
+        {
+            if (string.IsNullOrWhiteSpace(destinationOcclusionFilePath))
+            {
+                throw new ArgumentException("File path cannot be null or whitespace.", nameof(destinationOcclusionFilePath));
+            }
+
+            if (svg is null)
+            {
+                throw new ArgumentNullException(nameof(svg));
+            }
+
+            string tempOcclusionFilePath = Path.GetTempFileName();
+
+            try
+            {
+                await Task.Run(() => SaveToTemporaryFile(tempOcclusionFilePath, destinationOcclusionFilePath, svg));
+            }
+            finally
+            {
+                if (File.Exists(tempOcclusionFilePath))
+                {
+                    File.Delete(tempOcclusionFilePath);
+                }
+            }
+        }
+
+        private void SaveToTemporaryFile(string temporaryPath, string destinationPath, string svg)
+        {
+            using var skSvg = SKSvg.CreateFromSvg(svg);
+            skSvg.Save(
+                path: temporaryPath,
+                background: SKColors.Transparent,
+                format: SKEncodedImageFormat.Png);
+
+            WriteSvgToChunk(temporaryPath, svg);
+
+            if (File.Exists(destinationPath))
+            {
+                File.Delete(destinationPath);
+            }
+
+            File.Move(temporaryPath, destinationPath);
+        }
+
+        private static void WriteSvgToChunk(string pngFilePath, string svg)
+        {
+            using MemoryStream memoryStream = new MemoryStream();
+
+            using (FileStream fileStream = File.OpenRead(pngFilePath))
+            {
+                fileStream.CopyTo(memoryStream);
+            }
+
+            memoryStream.Seek(0, SeekOrigin.Begin);
+
+            PngReader pngReader = new PngReader(memoryStream);
+            PngWriter pngWriter = FileHelper.CreatePngWriter(pngFilePath, pngReader.ImgInfo, true);
+
+            pngWriter.CopyChunksFirst(pngReader, ChunkCopyBehaviour.COPY_ALL_SAFE);
+
+            CreateChunk(pngWriter, svg);
+
+            for (int row = 0; row < pngReader.ImgInfo.Rows; row++)
+            {
+                ImageLine imageLine = pngReader.ReadRow(row);
+                pngWriter.WriteRow(imageLine, row);
+            }
+
+            pngWriter.CopyChunksLast(pngReader, ChunkCopyBehaviour.COPY_ALL);
+
+            pngReader.End();
+            pngWriter.End();
+        }
+
+        private static void CreateChunk(PngWriter pngWriter, string svg)
+        {
+            PngChunkSVGI chunk = new PngChunkSVGI(pngWriter.ImgInfo)
+            {
+                Priority = true
+            };
+            chunk.SetSVG(svg);
+
+            pngWriter.GetChunksList().Queue(chunk);
+        }
+    }
+}

--- a/ImageOcclusionEditorWinUI3/Services/SvgEditorBridge.cs
+++ b/ImageOcclusionEditorWinUI3/Services/SvgEditorBridge.cs
@@ -1,0 +1,246 @@
+/*
+ * ImageOcclusionEditorWinUI3 - A WinUI 3 application for creating image occlusion cards
+ * Copyright (C) 2025 Shuai Zhang
+ *
+ * This file contains code derived from ImageOcclusionEditor by SuperMemo Community,
+ * which is licensed under the MIT License.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.Web.WebView2.Core;
+
+namespace ImageOcclusionEditorWinUI3.Services
+{
+    internal sealed class SvgEditorBridge : IDisposable
+    {
+        private const string AdditionalBrowserArguments = "--disable-features=msSmartScreenProtection --allow-file-access-from-files";
+
+        private const string KeyboardShortcutScript = @"
+                (function() {
+                    if (window.imageOcclusionKeyHandler) {
+                        document.removeEventListener('keydown', window.imageOcclusionKeyHandler, true);
+                        document.removeEventListener('keyup', window.imageOcclusionKeyHandler, true);
+                    }
+
+                    window.imageOcclusionHandlerActive = true;
+
+                    window.imageOcclusionKeyHandler = function(e) {
+                        if (!window.imageOcclusionHandlerActive) return;
+
+                        if (e.key === 'Escape') {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            e.stopImmediatePropagation();
+                            if (window.chrome && window.chrome.webview) {
+                                window.chrome.webview.postMessage('cancel');
+                            }
+                            return false;
+                        }
+                        else if (e.ctrlKey && e.shiftKey && (e.key === 'S' || e.key === 's')) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            e.stopImmediatePropagation();
+                            if (window.chrome && window.chrome.webview) {
+                                window.chrome.webview.postMessage('save');
+                            }
+                            return false;
+                        }
+                        else if (e.ctrlKey && !e.shiftKey && (e.key === 'S' || e.key === 's')) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            e.stopImmediatePropagation();
+                            if (window.chrome && window.chrome.webview) {
+                                window.chrome.webview.postMessage('saveExit');
+                            }
+                            return false;
+                        }
+                    };
+
+                    document.addEventListener('keydown', window.imageOcclusionKeyHandler, true);
+                    window.addEventListener('keydown', window.imageOcclusionKeyHandler, true);
+
+                    window.addEventListener('keyup', function(e) {
+                        if (!window.imageOcclusionHandlerActive) return;
+
+                        if (e.key === 'Escape' ||
+                            (e.ctrlKey && (e.key === 'S' || e.key === 's'))) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                        }
+                    }, true);
+
+                    console.log('Image Occlusion keyboard shortcuts injected successfully');
+
+                    setTimeout(function() {
+                        if (window.imageOcclusionHandlerActive && window.chrome && window.chrome.webview) {
+                            console.log('Keyboard shortcut handler still active');
+                        }
+                    }, 5000);
+                })();
+            ";
+
+        private readonly WebView2 _webView;
+        private bool _isReady;
+
+        public SvgEditorBridge(WebView2 webView)
+        {
+            _webView = webView ?? throw new ArgumentNullException(nameof(webView));
+            _webView.NavigationCompleted += HandleNavigationCompleted;
+            _webView.WebMessageReceived += HandleWebMessageReceived;
+        }
+
+        public event EventHandler? Ready;
+        public event EventHandler? SaveRequested;
+        public event EventHandler? SaveAndExitRequested;
+        public event EventHandler? CancelRequested;
+
+        public bool IsReady => _isReady;
+
+        public async Task InitializeAsync(string userDataFolder, Uri targetUri)
+        {
+            if (string.IsNullOrWhiteSpace(userDataFolder))
+            {
+                throw new ArgumentException("User data folder cannot be null or whitespace.", nameof(userDataFolder));
+            }
+
+            if (targetUri is null)
+            {
+                throw new ArgumentNullException(nameof(targetUri));
+            }
+
+            Directory.CreateDirectory(userDataFolder);
+
+            var environment = await CoreWebView2Environment.CreateWithOptionsAsync(
+                browserExecutableFolder: null,
+                userDataFolder: userDataFolder,
+                options: new CoreWebView2EnvironmentOptions
+                {
+                    AdditionalBrowserArguments = AdditionalBrowserArguments,
+                });
+
+            await _webView.EnsureCoreWebView2Async(environment);
+            ConfigureWebView();
+
+            _isReady = false;
+            _webView.CoreWebView2.Navigate(targetUri.ToString());
+        }
+
+        public async Task InjectKeyboardShortcutsAsync()
+        {
+            EnsureReady();
+            await _webView.CoreWebView2.ExecuteScriptAsync(KeyboardShortcutScript);
+        }
+
+        public async Task SetBackgroundAsync(Uri backgroundImageUri)
+        {
+            if (backgroundImageUri is null)
+            {
+                throw new ArgumentNullException(nameof(backgroundImageUri));
+            }
+
+            EnsureReady();
+            string script = $"svgEditor.setBackground(\"\", \"{backgroundImageUri.AbsoluteUri}\")";
+            await _webView.CoreWebView2.ExecuteScriptAsync(script);
+        }
+
+        public async Task SetSvgContentAsync(string svg)
+        {
+            if (svg is null)
+            {
+                throw new ArgumentNullException(nameof(svg));
+            }
+
+            EnsureReady();
+
+            string sanitized = svg.Replace("\r", string.Empty).Replace("\n", string.Empty).Replace("'", "\\'");
+            string script = $"svgEditor.loadSvgString('{sanitized}')";
+            string result = await _webView.CoreWebView2.ExecuteScriptAsync(script);
+
+            if (result == "false")
+            {
+                throw new InvalidOperationException("Failed to set SVG in browser.");
+            }
+        }
+
+        public async Task<string> GetSvgContentAsync()
+        {
+            EnsureReady();
+            string result = await _webView.CoreWebView2.ExecuteScriptAsync("svgEditor.svgCanvas.svgCanvasToString()");
+            return JsonSerializer.Deserialize(result, ImageOcclusionEditorWinUI3.JsonContext.Default.String) ?? string.Empty;
+        }
+
+        public void Dispose()
+        {
+            _webView.NavigationCompleted -= HandleNavigationCompleted;
+            _webView.WebMessageReceived -= HandleWebMessageReceived;
+        }
+
+        private void ConfigureWebView()
+        {
+            var settings = _webView.CoreWebView2.Settings;
+            settings.AreHostObjectsAllowed = true;
+            settings.IsWebMessageEnabled = true;
+            settings.AreDevToolsEnabled = false;
+            settings.IsGeneralAutofillEnabled = false;
+        }
+
+        private void HandleNavigationCompleted(object? sender, CoreWebView2NavigationCompletedEventArgs e)
+        {
+            if (!e.IsSuccess)
+            {
+                return;
+            }
+
+            if (_isReady)
+            {
+                return;
+            }
+
+            _isReady = true;
+            Ready?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void HandleWebMessageReceived(object? sender, CoreWebView2WebMessageReceivedEventArgs e)
+        {
+            string message = e.TryGetWebMessageAsString();
+
+            switch (message?.ToLowerInvariant())
+            {
+                case "cancel":
+                    CancelRequested?.Invoke(this, EventArgs.Empty);
+                    break;
+                case "save":
+                    SaveRequested?.Invoke(this, EventArgs.Empty);
+                    break;
+                case "saveexit":
+                    SaveAndExitRequested?.Invoke(this, EventArgs.Empty);
+                    break;
+            }
+        }
+
+        private void EnsureReady()
+        {
+            if (!_isReady || _webView.CoreWebView2 is null)
+            {
+                throw new InvalidOperationException("WebView2 is not ready.");
+            }
+        }
+    }
+}

--- a/ImageOcclusionEditorWinUI3/Services/SvgEditorNavigationBuilder.cs
+++ b/ImageOcclusionEditorWinUI3/Services/SvgEditorNavigationBuilder.cs
@@ -1,0 +1,73 @@
+/*
+ * ImageOcclusionEditorWinUI3 - A WinUI 3 application for creating image occlusion cards
+ * Copyright (C) 2025 Shuai Zhang
+ *
+ * This file contains code derived from ImageOcclusionEditor by SuperMemo Community,
+ * which is licensed under the MIT License.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.IO;
+using System.Text;
+
+namespace ImageOcclusionEditorWinUI3.Services
+{
+    internal static class SvgEditorNavigationBuilder
+    {
+        private const string SvgEditorPath = "svg-edit/index.html";
+
+        public static Uri Build(string backgroundFilePath, int width, int height)
+        {
+            if (string.IsNullOrWhiteSpace(backgroundFilePath))
+            {
+                throw new ArgumentException("File path cannot be null or whitespace.", nameof(backgroundFilePath));
+            }
+
+            Uri baseUri = new Uri(Path.Combine(AppContext.BaseDirectory, SvgEditorPath));
+            string query = BuildQuery(backgroundFilePath, width, height);
+
+            return string.IsNullOrEmpty(query) ? baseUri : new Uri($"{baseUri}?{query}");
+        }
+
+        private static string BuildQuery(string backgroundFilePath, int width, int height)
+        {
+            var builder = new StringBuilder();
+
+            AppendUrlParam(builder, "bkgd_url", backgroundFilePath);
+            AppendUrlParam(builder, "dimensions", $"{width},{height}");
+            AppendUrlParam(builder, "initFill[color]", ImageOcclusionEditorWinUI3.Settings.FillColor);
+            AppendUrlParam(builder, "initFill[opacity]", "1");
+            AppendUrlParam(builder, "initStroke[color]", ImageOcclusionEditorWinUI3.Settings.StrokeColor);
+            AppendUrlParam(builder, "initStroke[width]", ImageOcclusionEditorWinUI3.Settings.StrokeWidth);
+            AppendUrlParam(builder, "initStroke[opacity]", "1");
+            AppendUrlParam(builder, "storagePrompt", "false");
+
+            return builder.ToString().TrimStart('&');
+        }
+
+        private static void AppendUrlParam(StringBuilder builder, string key, string value)
+        {
+            if (builder.Length > 0)
+            {
+                builder.Append('&');
+            }
+
+            builder.Append(Uri.EscapeDataString(key));
+            builder.Append('=');
+            builder.Append(Uri.EscapeDataString(value));
+        }
+    }
+}

--- a/ImageOcclusionEditorWinUI3/packages.lock.json
+++ b/ImageOcclusionEditorWinUI3/packages.lock.json
@@ -33,15 +33,15 @@
       },
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[9.0.8, )",
-        "resolved": "9.0.8",
-        "contentHash": "cMwVh5hsxAhv+oMHQdgcXodt2kDpfviofBO4IXupSAHJW2vZOZOOIhvPWRGO6NeGcP8SR4OpSwktRqb0i79KFA=="
+        "requested": "[9.0.9, )",
+        "resolved": "9.0.9",
+        "contentHash": "jbi92xl2xcwGfdD/XSgOtOtQM5Ra3uXsiFuEyLnqwpHXeWHAutabi/LDu9VQbcuCqmvwOhrA3iFcvTIuFFQ0AQ=="
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[9.0.8, )",
-        "resolved": "9.0.8",
-        "contentHash": "rd1CbIsMtVPtZNTIVD6Xydue//klYOOQIDpRgu3BHtv17AlpRs74/6QFbcYgMm/jL+naVU2T3OFLxVSLV5lQLQ=="
+        "requested": "[9.0.9, )",
+        "resolved": "9.0.9",
+        "contentHash": "cHi1os/s6aobEgNkbOh/jW+ru//rHuedvj4PmTh2mMY7et/mJjqphBeXeKCesDvMd0+E2JyX9EPZZC4VRKslXg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -273,11 +273,11 @@
     "net9.0-windows10.0.22000/win-x64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
-        "requested": "[9.0.8, )",
-        "resolved": "9.0.8",
-        "contentHash": "cMwVh5hsxAhv+oMHQdgcXodt2kDpfviofBO4IXupSAHJW2vZOZOOIhvPWRGO6NeGcP8SR4OpSwktRqb0i79KFA==",
+        "requested": "[9.0.9, )",
+        "resolved": "9.0.9",
+        "contentHash": "jbi92xl2xcwGfdD/XSgOtOtQM5Ra3uXsiFuEyLnqwpHXeWHAutabi/LDu9VQbcuCqmvwOhrA3iFcvTIuFFQ0AQ==",
         "dependencies": {
-          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "9.0.8"
+          "runtime.win-x64.Microsoft.DotNet.ILCompiler": "9.0.9"
         }
       },
       "Microsoft.WindowsAppSDK": {
@@ -330,8 +330,8 @@
       },
       "runtime.win-x64.Microsoft.DotNet.ILCompiler": {
         "type": "Transitive",
-        "resolved": "9.0.8",
-        "contentHash": "VnA7D8XxNK1cNc2wlHCkdgDiTzCktzIixNYw0kyG7cy7fxXA07vkdLFXP72Cct4/7c7i8PL6JK3eTDqK/x6quQ=="
+        "resolved": "9.0.9",
+        "contentHash": "pNUVVZBgAw6mG4VQzHxzZmGyKMBD+VLi3kSPCvm8OoOtlIzRnh5bt36wfa5s0iHzFCp3v+ySAyH02Ns9RmNXNA=="
       },
       "SkiaSharp.NativeAssets.Win32": {
         "type": "Transitive",


### PR DESCRIPTION
The refactor changes observable behavior and is not functionally equivalent
to the previous implementation.

- MainWindow.xaml.cs:115  
  Close() is now in the same try block as the save logic, and line 132
  throws when the SVG payload is empty. Previously, SaveOcclusionAsync()
  simply returned on empty data while SaveOcclusionAndExitAsync() always
  closed afterward, so “Save & Exit” dismissed the window even if the
  WebView was not ready. Now the window stays open instead, which changes
  behavior.

- MainWindow.xaml.cs:79  
  Background load, overlay load, and keyboard shortcut injection are now
  wrapped in a single try/catch. Earlier, each helper
  (SetBackgroundInBrowser, SetSvgInBrowserAsync, InjectKeyboardShortcutHandler)
  caught its own errors and allowed later steps to proceed. Under the new
  structure, any failure aborts the remaining setup.

- SvgEditorBridge.cs:163  
  An InvalidOperationException is now thrown when svgEditor.loadSvgString
  reports "false". Previously the code only displayed an error dialog and
  continued. With the consolidated catch in OnSvgEditorReady, scenarios
  that used to show a warning and yield partial functionality now stop
  initialization entirely.

Net effect: errors that were recoverable in the old design now prevent
further execution, altering runtime behavior.
